### PR TITLE
detect aarch64 in Makefile, and make mask2iupac signed char

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rhisat2
 Type: Package
 Title: R Wrapper for HISAT2 Aligner
-Version: 1.19.0
+Version: 1.19.1
 Authors@R: c(person("Charlotte", "Soneson", role = c("aut", "cre"), 
     email = "charlottesoneson@gmail.com", comment = c(ORCID = "0000-0003-3833-2169")))
 SystemRequirements: GNU make
@@ -10,7 +10,7 @@ Description: An R interface to the HISAT2 spliced short-read aligner by
     genome index and to perform the read alignment to the generated index.
 License: GPL-3
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends: R (>= 4.2)
 Suggests: testthat,
     knitr,

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+CHANGES IN VERSION 1.19.1
+-------------------------
+
+    o Exclude unsupported flags in Makefile for Linux aarch64 platform
+    o Make mask2iupac a signed char array
+
 CHANGES IN VERSION 1.13.1
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `Rhisat2` R package provides an R interface to the [`hisat2`](https://ccb.jh
 
 #### Rhisat2 v1.19.1 and newer
 
-To allow compilation on Linux aarch64, the Makefile obtained from hisat2 was adapted to exclude unsupported flags (`-m64` and `-msse2`) on this platform. In addition, the `mask2iupac` array was converted from a `char` to a `signed char`. See [here](https://github.com/fmicompbio/Rhisat2/pull/5/files) for the precise changes. 
+To allow compilation also on Linux aarch64, the Makefile obtained from hisat2 was adapted to exclude unsupported flags (`-m64` and `-msse2`) on this platform. In addition, the `mask2iupac` array was converted from a `char` to a `signed char`. See [here](https://github.com/fmicompbio/Rhisat2/pull/5/files) for the precise changes. 
 
 #### Rhisat2 v1.13.1 and newer
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The `Rhisat2` R package provides an R interface to the [`hisat2`](https://ccb.jh
 
 ### Source code
 
+#### Rhisat2 v1.19.1 and newer
+
+To allow compilation on Linux aarch64, the Makefile obtained from hisat2 was adapted to exclude unsupported flags (`-m64` and `-msse2`) on this platform. In addition, the `mask2iupac` array was converted from a `char` to a `signed char`. See [here](https://github.com/fmicompbio/Rhisat2/pull/5/files) for the precise changes. 
+
 #### Rhisat2 v1.13.1 and newer
 
 In Rhisat2 v1.13.1 and onwards, hisat2 was updated to v2.2.1, which was obtained from [https://github.com/DaehwanKimLab/hisat2/releases](https://github.com/DaehwanKimLab/hisat2/releases) on July 27, 2022. 

--- a/src/Makefile
+++ b/src/Makefile
@@ -85,6 +85,12 @@ ifneq (,$(findstring Darwin,$(shell uname)))
 	MACOS = 1
 endif
 
+AARCH64 = 0
+ifneq (,$(findstring aarch64,$(shell uname -m)))
+  AARCH64 = 1
+endif
+
+
 EXTRA_FLAGS += -std=c++11
 INC += -I. -I third_party
 
@@ -200,9 +206,14 @@ BITS_FLAG =
 #endif
 
 ifeq (64,$(BITS))
-	BITS_FLAG = -m64
+  ifeq (0, $(AARCH64))
+  	BITS_FLAG = -m64
+  endif
 endif
-SSE_FLAG=-msse2
+SSE_FLAG =
+ifeq (0, $(AARCH64))
+  SSE_FLAG=-msse2
+endif
 
 DEBUG_FLAGS    = -O0 -g3 $(BITS_FLAG) $(SSE_FLAG)
 DEBUG_DEFS     = -DCOMPILER_OPTIONS="\"$(DEBUG_FLAGS) $(EXTRA_FLAGS)\""

--- a/src/alphabet.cpp
+++ b/src/alphabet.cpp
@@ -400,7 +400,7 @@ int dnacomp[5] = {
 
 const char *iupacs = "!ACMGRSVTWYHKDBN!acmgrsvtwyhkdbn";
 
-char mask2iupac[16] = {
+signed char mask2iupac[16] = {
 	-1,
 	'A', // 0001
 	'C', // 0010

--- a/src/alphabet.h
+++ b/src/alphabet.h
@@ -65,7 +65,7 @@ extern uint8_t dinuc2color[5][5];
 /// corresponding 2-bit nucleotide
 extern uint8_t nuccol2nuc[5][5];
 /// Convert a 4-bit mask into an IUPAC code
-extern char mask2iupac[16];
+extern signed char mask2iupac[16];
 
 /// Convert an ascii color to an ascii dna char
 extern char col2dna[];


### PR DESCRIPTION
`Rhisat2` is failing on Bioc linux-aarch64 with:
```
g++: error: unrecognized command-line option ‘-m64’
g++: error: unrecognized command-line option ‘-msse2’
make: *** [Makefile:363: hisat2-build-s] Error 1
ERROR: compilation failed for package ‘Rhisat2’
```

This PR changes the logic in `Makefile` to exclude the two flags on that platform, and makes a `char` array `signed char` which seems to be required for compiling.